### PR TITLE
Create POC with hooks of do_fork, elf loading and kill

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,26 +3,67 @@
 
 #include "khook/engine.c"
 
-////////////////////////////////////////////////////////////////////////////////
-// An example of using KHOOK
-////////////////////////////////////////////////////////////////////////////////
-
 #include <linux/fs.h>
+#include <linux/sched.h>
 
-KHOOK(inode_permission);
-static int khook_inode_permission(struct inode *inode, int mask)
-{
-	int ret = 0;
+/*******************************************************************************
+* Hooking _do_fork
+*
+* It looks that several syscalls related to process creation eventually call
+* __do_fork. Therefore it is better to hook it rather than individual syscalls.
+*
+*******************************************************************************/
 
-	ret = KHOOK_ORIGIN(inode_permission, inode, mask);
-	printk("%s(%p, %08x) = %d\n", __func__, inode, mask, ret);
+KHOOK_EXT(long, _do_fork, unsigned long clone_flags,
+							unsigned long stack_start,
+							unsigned long stack_size,
+							int __user *parent_tidptr,
+							int __user *child_tidptr,
+							unsigned long tls);
+static long khook__do_fork(unsigned long clone_flags,
+							unsigned long stack_start, unsigned long stack_size,
+							int __user *parent_tidptr, int __user *child_tidptr,
+							unsigned long tls) {
+	long ret = 0;
 
+	ret = KHOOK_ORIGIN(_do_fork, clone_flags, stack_start, stack_size,
+		parent_tidptr, child_tidptr, tls);
+
+	printk("%s: executable %s, pid %ld\n", __func__, current->comm, ret);
 	return ret;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// An example of using KHOOK_EXT
-////////////////////////////////////////////////////////////////////////////////
+/*******************************************************************************
+* Hooking sys_kill and __x64_sys_kill
+*
+* Newer kernels changed their prefix for syscalls there for __x64_sys_kill
+* should be tracked.
+*
+*******************************************************************************/
+
+// long sys_kill(pid_t pid, int sig)
+KHOOK_EXT(long, sys_kill, long, long);
+static long khook_sys_kill(long pid, long sig) {
+	printk("%s: executable %s, pid %ld, sig %ld\n", __func__, current->comm,
+		pid, sig);
+	return KHOOK_ORIGIN(sys_kill, pid, sig);
+}
+
+// This is the hook when process is killed. For example by "kill -9 <pid>"
+// long sys_kill(const struct pt_regs *regs) -- modern kernels
+KHOOK_EXT(long, __x64_sys_kill, const struct pt_regs *);
+static long khook___x64_sys_kill(const struct pt_regs *regs) {
+	printk("%s: executable %s, pid %ld, sig %ld\n", __func__, current->comm,
+		regs->di, regs->si);
+	return KHOOK_ORIGIN(__x64_sys_kill, regs);
+}
+
+/*******************************************************************************
+* Hooking load_elf_binary
+*
+* We are going to get executable name and additional information here after elf
+* is loaded. Some of this useful info can be VM_AREAs of the task.
+*******************************************************************************/
 
 #include <linux/binfmts.h>
 
@@ -32,12 +73,13 @@ static int khook_load_elf_binary(struct linux_binprm *bprm)
 	int ret = 0;
 
 	ret = KHOOK_ORIGIN(load_elf_binary, bprm);
-	printk("%s(%p) = %d\n", __func__, bprm, ret);
+	printk("%s: filename %s, real file name %s, return %d\n", __func__,
+		bprm->filename, bprm->interp, ret);
+
+	/* Worth also looking into bprm->vma_pages and  bprm->vma */
 
 	return ret;
 }
-
-////////////////////////////////////////////////////////////////////////////////
 
 int init_module(void)
 {
@@ -49,4 +91,6 @@ void cleanup_module(void)
 	khook_cleanup();
 }
 
-MODULE_LICENSE("GPL\0but who really cares?");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Hooking processes creation and termination");
+MODULE_AUTHOR("Yan Vugenfirer <yan@bladerunner.io> based on work by Ilya V. Matveychikov");


### PR DESCRIPTION
1. Remove some sample code

2. Hooking _do_fork:
It looks that several syscalls related to process creation eventually call
 __do_fork. Therefore it is better to hook it rather than individual syscalls.

3. Hooking sys_kill and __x64_sys_kill:
Newer kernels changed their prefix for syscalls there for __x64_sys_kill
should be tracked.

4. Hooking load_elf_binary
We are going to get executable name and additional information here after elf
is loaded. Some of this useful info can be VM_AREAs of the task.

Signed-off-by: Yan Vugenfirer <yan@bladerunner.io>